### PR TITLE
allowing SLine to be dereffed into its inner string

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ mod parsing_lines;
 use parsing_lines::ParsingLines;
 use process_line::process_line;
 
+use std::ops::Deref;
 
 // ------------------------------------------------------------------
 // ------------------------------------------------------------------
@@ -63,6 +64,14 @@ impl SLine {
         SLine(String::from(s))
     }
 }
+
+impl Deref for SLine {
+    type Target = str;
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
 
 
 #[cfg(test)]


### PR DESCRIPTION
Hi there, nice tokeninzer you got there.
I was playing around with it yesterday and did not actually find a way to access the content of an `SLine` therefore I made this little addition.
What do you think?